### PR TITLE
#8324525 Downgrade css-selector and dom-crawler version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Utils for testing SonataAdminBundle",
   "homepage": "https://github.com/AVE-Systems/sonata-test-utils",
   "license": "Apache-2.0",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "type": "library",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,9 @@
     "php": ">=7.2",
     "ext-json": "*",
     "ext-dom": "*",
-    "symfony/css-selector": "^4.4",
-    "symfony/dom-crawler": "^4.4"
+    "sonata-project/admin-bundle": "^3.0",
+    "symfony/css-selector": "*",
+    "symfony/dom-crawler": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5"

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
   "require": {
     "php": ">=7.2",
     "ext-json": "*",
-    "symfony/dom-crawler": "*",
-    "symfony/css-selector": "*",
-    "ext-dom": "*"
+    "ext-dom": "*",
+    "symfony/css-selector": "^4.4",
+    "symfony/dom-crawler": "^4.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5"

--- a/src/SonataAdminActionsTrait.php
+++ b/src/SonataAdminActionsTrait.php
@@ -256,7 +256,7 @@ trait SonataAdminActionsTrait
         return $crawler
             ->filterXPath($xpath)
             ->each(function (Crawler $element) {
-                return $element->text();
+                return $element->evaluate('normalize-space(.)')[0];
             });
     }
 }

--- a/src/SonataAdminFlashMessagesTrait.php
+++ b/src/SonataAdminFlashMessagesTrait.php
@@ -7,13 +7,13 @@ use Symfony\Component\DomCrawler\Crawler;
 /**
  * Makes easier flash messages checking.
  *
- * @method void assertGreaterThan(int $expected, $actual, string $message = '')
+ * @method void assertContains($needle, $haystack, string $message = '', bool $ignoreCase = false, bool $checkForObjectIdentity = true, bool $checkForNonObjectIdentity = false)
  * @method void assertTrue($condition, string $message = '')
  * @method void assertEquals($expected, $actual, string $message = '', float $delta = 0.0, int $maxDepth = 10, bool $canonicalize = false, bool $ignoreCase = false)
  *
- * @see Assert::assertGreaterThan
- * @see Assert::assertTrue
- * @see Assert::assertEquals
+ * @see Assert::assertContains()
+ * @see Assert::assertTrue()
+ * @see Assert::assertEquals()
  */
 trait SonataAdminFlashMessagesTrait
 {
@@ -27,22 +27,9 @@ trait SonataAdminFlashMessagesTrait
         string $message,
         Crawler $crawler
     ): void {
-        $nodes = $this->findFlashSuccessMessages($crawler)->getIterator();
-
-        $this->assertGreaterThan(
-            0,
-            $nodes->count(),
-            'No success flash messages'
-        );
-
-        $matched = false;
-        foreach ($nodes as $node) {
-            if (preg_match("~{$message}~", $node->nodeValue)) {
-                $matched = true;
-            }
-        }
-        $this->assertTrue(
-            $matched,
+        $this->assertContains(
+            $message,
+            $this->findFlashSuccessMessages($crawler),
             'No success flash messages with text "'.$message.'".'
         );
     }
@@ -56,24 +43,9 @@ trait SonataAdminFlashMessagesTrait
         string $message,
         Crawler $crawler
     ): void {
-        $nodes = $this->findFlashInfoMessages($crawler)->getIterator();
-
-        $this->assertGreaterThan(
-            0,
-            $nodes->count(),
-            'No info flash messages'
-        );
-
-        $matched = false;
-
-        foreach ($nodes as $node) {
-            if (preg_match("~{$message}~", $node->nodeValue)) {
-                $matched = true;
-            }
-        }
-
-        $this->assertTrue(
-            $matched,
+        $this->assertContains(
+            $message,
+            $this->findFlashInfoMessages($crawler),
             'No info flash messages with text "'.$message.'".'
         );
     }
@@ -88,22 +60,9 @@ trait SonataAdminFlashMessagesTrait
         string $error,
         Crawler $crawler
     ): void {
-        $nodes = $this->findFlashErrorMessages($crawler)->getIterator();
-
-        $this->assertGreaterThan(
-            0,
-            $nodes->count(),
-            'No error flash messages'
-        );
-
-        $matched = false;
-        foreach ($nodes as $node) {
-            if (preg_match("~{$error}~", $node->nodeValue)) {
-                $matched = true;
-            }
-        }
-        $this->assertTrue(
-            $matched,
+        $this->assertContains(
+            $error,
+            $this->findFlashErrorMessages($crawler),
             'No error flash messages with text "'.$error.'".'
         );
     }
@@ -116,9 +75,9 @@ trait SonataAdminFlashMessagesTrait
      */
     protected function assertFlashErrorMessagesCount(int $count, Crawler $crawler)
     {
-        $this->assertEquals(
+        $this->assertCount(
             $count,
-            $this->findFlashErrorMessages($crawler)->count()
+            $this->findFlashErrorMessages($crawler)
         );
     }
 
@@ -132,22 +91,9 @@ trait SonataAdminFlashMessagesTrait
         string $expectedMessage,
         Crawler $crawler
     ): void {
-        $nodes = $this->findFlashWarningMessages($crawler)->getIterator();
-
-        $this->assertGreaterThan(
-            0,
-            $nodes->count(),
-            'No warning flash messages'
-        );
-
-        $matched = false;
-        foreach ($nodes as $node) {
-            if (preg_match("~{$expectedMessage}~", $node->nodeValue)) {
-                $matched = true;
-            }
-        }
-        $this->assertTrue(
-            $matched,
+        $this->assertContains(
+            $expectedMessage,
+            $this->findFlashWarningMessages($crawler),
             'No warning flash messages with text "'.$expectedMessage.'".'
         );
     }
@@ -155,52 +101,56 @@ trait SonataAdminFlashMessagesTrait
     /**
      * Find error flash messages.
      *
-     * @param Crawler $crawler
-     *
-     * @return Crawler
+     * @return string[]
      */
-    private function findFlashErrorMessages(Crawler $crawler)
+    private function findFlashErrorMessages(Crawler $crawler): array
     {
         return $crawler
-            ->filter('div[class="alert alert-error fade in"]');
+            ->filter('div[class="alert alert-error fade in"]')
+            ->each(function (Crawler $element) {
+                return $element->evaluate('normalize-space(.)')[0];
+            });
     }
 
     /**
      * Find success flash messages.
      *
-     * @param Crawler $crawler
-     *
-     * @return Crawler
+     * @return string[]
      */
-    private function findFlashSuccessMessages(Crawler $crawler)
+    private function findFlashSuccessMessages(Crawler $crawler): array
     {
         return $crawler
-            ->filter('div[class="alert alert-success fade in"]');
+            ->filter('div[class="alert alert-success fade in"]')
+            ->each(function (Crawler $element) {
+                return $element->evaluate('normalize-space(.)')[0];
+            });
     }
 
     /**
      * Find info flash messages.
      *
-     * @param Crawler $crawler
-     *
-     * @return Crawler
+     * @return string[]
      */
-    private function findFlashInfoMessages(Crawler $crawler)
+    private function findFlashInfoMessages(Crawler $crawler): array
     {
         return $crawler
-            ->filter('div[class="alert alert-info fade in"]');
+            ->filter('div[class="alert alert-info fade in"]')
+            ->each(function (Crawler $element) {
+                return $element->evaluate('normalize-space(.)')[0];
+            });
     }
 
     /**
      * Find warning flash messages.
      *
-     * @param Crawler $crawler
-     *
-     * @return Crawler
+     * @return string[]
      */
-    private function findFlashWarningMessages(Crawler $crawler)
+    private function findFlashWarningMessages(Crawler $crawler): array
     {
         return $crawler
-            ->filter('div[class="alert alert-warning fade in"]');
+            ->filter('div[class="alert alert-warning fade in"]')
+            ->each(function (Crawler $element) {
+                return $element->evaluate('normalize-space(.)')[0];
+            });
     }
 }

--- a/tests/SonataAdminFlashMessagesTraitTest.php
+++ b/tests/SonataAdminFlashMessagesTraitTest.php
@@ -124,12 +124,12 @@ HTML;
         $crawler->addHtmlContent($content);
 
         $this->assertFlashSuccessMessageExists(
-            'Представитель учредителя оповещен',
+            '× Представитель учредителя оповещен.',
             $crawler
         );
 
         $this->assertFlashSuccessMessageExists(
-            'Отправлено в архив',
+            '× Отправлено в архив.',
             $crawler
         );
     }
@@ -148,7 +148,7 @@ HTML;
         $this->expectException(ExpectationFailedException::class);
 
         $this->assertFlashErrorMessageExists(
-            'Отправлено в архив',
+            '× Отправлено в архив',
             $crawler
         );
     }
@@ -167,7 +167,7 @@ HTML;
         $this->expectException(ExpectationFailedException::class);
 
         $this->assertFlashSuccessMessageExists(
-            'Оповещение отправлено.',
+            '× Оповещение отправлено.',
             $crawler
         );
     }
@@ -184,12 +184,12 @@ HTML;
         $crawler->addHtmlContent($content);
 
         $this->assertFlashWarningMessageExists(
-            'Предупреждение',
+            '× Предупреждение.',
             $crawler
         );
 
         $this->assertFlashWarningMessageExists(
-            'Некритичная ошибка',
+            '× Некритичная ошибка.',
             $crawler
         );
     }
@@ -208,7 +208,7 @@ HTML;
         $this->expectException(ExpectationFailedException::class);
 
         $this->assertFlashErrorMessageExists(
-            'Предупреждение',
+            '× Предупреждение',
             $crawler
         );
     }
@@ -227,7 +227,7 @@ HTML;
         $this->expectException(ExpectationFailedException::class);
 
         $this->assertFlashWarningMessageExists(
-            'Предупреждение',
+            '× Предупреждение',
             $crawler
         );
     }
@@ -244,12 +244,12 @@ HTML;
         $crawler->addHtmlContent($content);
 
         $this->assertFlashErrorMessageExists(
-            'Произошла ошибка в редактировании названия.',
+            '× Произошла ошибка в редактировании названия.',
             $crawler
         );
 
         $this->assertFlashErrorMessageExists(
-            'Не удалось оповестить админа.',
+            '× Не удалось оповестить админа.',
             $crawler
         );
     }
@@ -268,7 +268,7 @@ HTML;
         $this->expectException(ExpectationFailedException::class);
 
         $this->assertFlashSuccessMessageExists(
-            'Не удалось оповестить админа.',
+            '× Не удалось оповестить админа.',
             $crawler
         );
     }
@@ -287,7 +287,7 @@ HTML;
         $this->expectException(ExpectationFailedException::class);
 
         $this->assertFlashErrorMessageExists(
-            'Произошла ошибка в редактировании названия.',
+            '× Произошла ошибка в редактировании названия.',
             $crawler
         );
     }
@@ -334,12 +334,12 @@ HTML;
         $crawler->addHtmlContent($content);
 
         $this->assertFlashInfoMessageExists(
-            'Информационное сообщение',
+            '× Информационное сообщение.',
             $crawler
         );
 
         $this->assertFlashInfoMessageExists(
-            'Оповещение',
+            '× Оповещение.',
             $crawler
         );
     }
@@ -358,7 +358,7 @@ HTML;
         $this->expectException(ExpectationFailedException::class);
 
         $this->assertFlashInfoMessageExists(
-            'Отправлено в архив',
+            '× Отправлено в архив',
             $crawler
         );
     }
@@ -377,7 +377,7 @@ HTML;
         $this->expectException(ExpectationFailedException::class);
 
         $this->assertFlashInfoMessageExists(
-            'Оповещение отправлено.',
+            '× Оповещение отправлено.',
             $crawler
         );
     }
@@ -393,18 +393,14 @@ HTML;
         $crawler = $this->getCrawler();
         $crawler->addHtmlContent($content);
 
-        $nodes = $this->findFlashErrorMessages($crawler);
-
-        $this->assertCount(2, $nodes);
+        $messages = $this->findFlashErrorMessages($crawler);
 
         $this->assertEquals(
-            '× Произошла ошибка в редактировании названия.',
-            $nodes->eq(0)->text()
-        );
-
-        $this->assertEquals(
-            '× Не удалось оповестить админа.',
-            $nodes->eq(1)->text()
+            [
+                '× Произошла ошибка в редактировании названия.',
+                '× Не удалось оповестить админа.'
+            ],
+            $messages
         );
     }
 
@@ -419,18 +415,14 @@ HTML;
         $crawler = $this->getCrawler();
         $crawler->addHtmlContent($content);
 
-        $nodes = $this->findFlashSuccessMessages($crawler);
-
-        $this->assertCount(2, $nodes);
+        $messages = $this->findFlashSuccessMessages($crawler);
 
         $this->assertEquals(
-            '× Представитель учредителя оповещен.',
-            $nodes->eq(0)->text()
-        );
-
-        $this->assertEquals(
-            '× Отправлено в архив.',
-            $nodes->eq(1)->text()
+            [
+                '× Представитель учредителя оповещен.',
+                '× Отправлено в архив.'
+            ],
+            $messages
         );
     }
 
@@ -445,18 +437,14 @@ HTML;
         $crawler = $this->getCrawler();
         $crawler->addHtmlContent($content);
 
-        $nodes = $this->findFlashWarningMessages($crawler);
-
-        $this->assertCount(2, $nodes);
+        $messages = $this->findFlashWarningMessages($crawler);
 
         $this->assertEquals(
-            '× Предупреждение.',
-            $nodes->eq(0)->text()
-        );
-
-        $this->assertEquals(
-            '× Некритичная ошибка.',
-            $nodes->eq(1)->text()
+            [
+                '× Предупреждение.',
+                '× Некритичная ошибка.'
+            ],
+            $messages
         );
     }
 
@@ -471,18 +459,14 @@ HTML;
         $crawler = $this->getCrawler();
         $crawler->addHtmlContent($content);
 
-        $nodes = $this->findFlashInfoMessages($crawler);
-
-        $this->assertCount(2, $nodes);
+        $messages = $this->findFlashInfoMessages($crawler);
 
         $this->assertEquals(
-            '× Информационное сообщение.',
-            $nodes->eq(0)->text()
-        );
-
-        $this->assertEquals(
-            '× Оповещение.',
-            $nodes->eq(1)->text()
+            [
+                '× Информационное сообщение.',
+                '× Оповещение.',
+            ],
+            $messages
         );
     }
 


### PR DESCRIPTION
Пришлось понизить версию библиотек, т.к. у нас на справке более низкая версия, где Crawler::text не нормализует пробелы по-умолчанию, даже вообще ещё не умеет это делать. До понижения версии тесты на справке заваливались, а здесь нет. По этой же причине пришлось переписать несколько ассертов и тестов